### PR TITLE
Update Readme : `small improments`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align="center"> Hypersonic - NeoVim Plugin for Regex Writing and Testing </h1>
 
 <p align="center">
-    A powerful NeoVim plugin created to increase your regular expression (RegExp) writing and testing experience. 
+    A powerful NeoVim plugin created to increase your regular expression (RegExp) writing and testing experience.
     Whether you're a newbie or profesional developer, Hypersonic is here to make your life easier and boost your productivity
 </p>
 
@@ -22,9 +22,9 @@
 
 
 ## Currently accessible
-- Simple RegExp explaining
+- Simple **RegExp** *explaining*
+- **CommandLine** *live* *explanation*
 - Language support for LUA
-- CommandLine live explanation
 
 ## Known issues
 - Does not work in v`0.8.3` (only tested one)
@@ -76,15 +76,16 @@ use 'tomiis4/Hypersonic.nvim'
 <summary> Using lazy </summary>
 
 ```lua
-return {
+ {
     'tomiis4/Hypersonic.nvim',
+    event = "CmdlineEnter",
     cmd = "Hypersonic",
     config = function()
         require('hypersonic').setup({
             -- config
         })
     end
-}
+},
 ```
 
 </details>
@@ -307,7 +308,7 @@ local meta_table = {
 {
     {'',  'gr[ae]y'},
     {'gr',     'Match gr'},
-    {'[ae]',   'Match either', 
+    {'[ae]',   'Match either',
         {'one character from list ae'},
     },
     {'y',      'Match "y"'}


### PR DESCRIPTION
Hello, im the Guy from reddit u met for CMDLINE ,

i have changed the Readme.md as follow
- highlight stuff **BOLD** &  *italic* when needed 
- removed `**Return**` statement, i dont think many pepe's be using spec for this? idk but , it depends on who's going to use

fixed : 
- fix : removed need of doing `:Hyperfine` before /search
- added : **TRULY** _lazyloading_ experience (partialy) , 

some info : 
event = "cmdlineenter"
means , when u start to use `/`, `?`, `:` 
u can even strip it down with using `keys` function which maybe better, `cmdlinenter` is Enough for most